### PR TITLE
Limit scheduledForDestruction assert to brain transplants

### DIFF
--- a/js/src/gc/Marking.cpp
+++ b/js/src/gc/Marking.cpp
@@ -89,10 +89,12 @@ CheckMarkedThing(JSTracer *trc, T *thing)
     JS_ASSERT(thing);
     JS_ASSERT(thing->compartment());
     JS_ASSERT(thing->compartment()->rt == trc->runtime);
-    JS_ASSERT_IF(IS_GC_MARKING_TRACER(trc), !thing->compartment()->scheduledForDestruction);
     JS_ASSERT(trc->debugPrinter || trc->debugPrintArg);
 
     DebugOnly<JSRuntime *> rt = trc->runtime;
+
+    JS_ASSERT_IF(IS_GC_MARKING_TRACER(trc) && rt->gcManipulatingDeadCompartments,
+                 !thing->compartment()->scheduledForDestruction);
 
     JS_ASSERT_IF(thing->compartment()->requireGCTracer(), IS_GC_MARKING_TRACER(trc));
 


### PR DESCRIPTION
 (backported fix from Mozilla)
- https://bugzilla.mozilla.org/show_bug.cgi?id=811587#c27
- https://hg.mozilla.org/integration/mozilla-inbound/rev/6457767f5277
