### PR TITLE
Spidermonkey should be built in RELEASE mode for all platforms.

### DIFF
--- a/js/src/build-ios/build.sh
+++ b/js/src/build-ios/build.sh
@@ -21,7 +21,7 @@ cpus=$(sysctl hw.ncpu | awk '{print $2}')
 ../configure --with-ios-target=iPhoneSimulator --with-ios-version=$IOS_SDK --with-ios-min-version=$MIN_IOS_VERSION \
             --disable-shared-js --disable-tests --disable-ion --disable-jm --disable-tm --enable-llvm-hacks --disable-methodjit --disable-monoic --disable-polyic \
             --enable-optimize=-O3 --enable-strip --enable-install-strip \
-            --enable-debug --enable-intl-api=no
+            --disable-debug --enable-intl-api=no
 make -j$cpus
 if (( $? )) ; then
     echo "error when compiling i386 (iOS Simulator) version of the library"
@@ -35,7 +35,7 @@ mv libjs_static.a libjs_static.i386.a
 #
 ../configure --with-ios-target=iPhoneOS --with-ios-version=$IOS_SDK --with-ios-min-version=$MIN_IOS_VERSION --with-ios-arch=armv7 \
             --disable-shared-js --disable-tests --disable-ion --disable-jm --disable-tm --enable-llvm-hacks --disable-methodjit --disable-monoic --disable-polyic --disable-yarr-jit \
-            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no
+            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no --disable-debug
 make -j$cpus
 if (( $? )) ; then
     echo "error when compiling iOS version of the library"
@@ -51,7 +51,7 @@ mv libjs_static.a libjs_static.armv7.a
 #../configure --with-ios-target=iPhoneOS --with-ios-version=$IOS_SDK --with-ios-min-version=$MIN_IOS_VERSION --with-ios-arch=armv7s  --disable-shared-js --disable-tests --disable-ion --disable-jm --disable-tm --enable-llvm-hacks --disable-methodjit --with-thumb=yes --enable-strip --enable-install-strip --disable-monoic --disable-polyic --disable-ion --enable-optimize=-O1
 ../configure --with-ios-target=iPhoneOS --with-ios-version=$IOS_SDK --with-ios-min-version=$MIN_IOS_VERSION --with-ios-arch=armv7s \
             --disable-shared-js --disable-tests --disable-ion --disable-jm --disable-tm --enable-llvm-hacks --disable-methodjit --disable-monoic --disable-polyic --disable-yarr-jit \
-            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no
+            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no --disable-debug
 make -j$cpus
 if (( $? )) ; then
     echo "error when compiling iOS version of the library"

--- a/js/src/build-ios/build64.sh
+++ b/js/src/build-ios/build64.sh
@@ -26,7 +26,7 @@ make distclean
 
 ../configure --with-ios-target=iPhoneOS --with-ios-version=$IOS_SDK --with-ios-min-version=$MIN_IOS_VERSION --with-ios-arch=arm64 \
             --disable-shared-js --disable-tests --disable-ion --disable-jm --disable-tm --enable-llvm-hacks --disable-methodjit --disable-monoic --disable-polyic --disable-yarr-jit \
-            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no
+            --enable-optimize=-O3 --with-thumb=yes --enable-strip --enable-install-strip --enable-intl-api=no --disable-debug
 make -j$cpus
 if (( $? )) ; then
     echo "error when compiling iOS version of the library"

--- a/js/src/build-osx/build.sh
+++ b/js/src/build-osx/build.sh
@@ -7,7 +7,7 @@ cpus=$(sysctl hw.ncpu | awk '{print $2}')
             --enable-strip --enable-strip-install \
             --disable-root-analysis --disable-exact-rooting --enable-gcincremental --enable-optimize=-O3 \
             --enable-llvm-hacks \
-            --enable-debug \
+            --disable-debug \
             --enable-intl-api=no
 # make
 xcrun make -j$cpus


### PR DESCRIPTION
Relevant issues were created at 
http://www.cocos2d-x.org/issues/3853
http://www.cocos2d-x.org/issues/3857
### REASON WHY WE HAVE TO USE RELEASE VERSION LIBRARY:

We used fat library for iOS, it contains `i386`, `armv7`, `armv7s` architecture. But we use the same header files.
The head file of Spidermonkey contains DEBUG macro in some methods or some classes. It may lead to weird crash.
### HOW TO FIX:

Undefine all `DEBUG` marcos in Project Settings.
Build all libraries in `RELEASE` mode.

**If you wish to debug Spidermonkey, you have to know how to build debug version of SpiderMonkey and how to set DEBUG macro in Project Setting!**
### BUT DON'T DEFINE `DEBUG` macro IN OUR PROJECTS

Cocos2d-x is using `COCOS2D_DEBUG` for debugging.
