### PR TITLE
Fix linux build

### DIFF
--- a/js/src/builtin/Array.js
+++ b/js/src/builtin/Array.js
@@ -1,0 +1,1 @@
+array.js


### PR DESCRIPTION
Linux is case sensitive, and [Makefile.in](https://github.com/ricardoquesada/Spidermonkey/blob/master/js/src/Makefile.in#L597) searchs for `Array.js`, but the file is called `array.js` upstream.
This PR simply adds a symlink from `Array.js` to `array.js` so it will not happen again.
